### PR TITLE
fixed genre scrolling and decade bug

### DIFF
--- a/src/components/DisplayMovies.js
+++ b/src/components/DisplayMovies.js
@@ -1,5 +1,5 @@
 import '../styles/displayMovies.css'
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, Children } from 'react';
 import { useSwipeable } from "react-swipeable";
 import MoviePopover from './MoviePopovers'
 
@@ -7,21 +7,17 @@ function DisplayMovies({movieObjects, searchObj}) {
   const [myMoviesObject, setMyMoviesObject] = useState();
   const [numberOfMoviesDisplayed, setNumberOfMoviesDisplayed] = useState();
   const [screenWidth, setScreenWidth] = useState(0);
-  const decade = useRef()
+
 
   useEffect(() => {
-    if(movieObjects !== undefined && movieObjects.length > 0){
-      if(movieObjects !== myMoviesObject){
-        setMyMoviesObject(movieObjects)
-      }
+    if(movieObjects.length > 0){
+      setMyMoviesObject(movieObjects)
     }
-    if(searchObj.decade !== decade.current){
-      decade.current = searchObj.decade
-    }
-  });
+  },[movieObjects]);
+
   useEffect(()=>{
-    if(searchObj.genre !== undefined && searchObj.genre !== null){
-        scrollToGenre()
+    if(myMoviesObject !== undefined){
+      scrollToGenre()
     }
   },[searchObj.genre])
 

--- a/src/components/FetchMovieData.js
+++ b/src/components/FetchMovieData.js
@@ -35,7 +35,9 @@ export default function FetchMovieData(props) {
       for (let index = 0; index < apiCallData.length; index++) {
        if(apiCallData[index] !== undefined){
           const movieList = await fetchMovies(apiCallData[index].apiCall)
-          finalMoiveData.push(AaddMovie(apiCallData[index].genreName, movieList))
+          if(movieList.length > 0){
+            finalMoiveData.push(AaddMovie(apiCallData[index].genreName, movieList))
+          }
         }
       }
       setMovieObjects(finalMoiveData)


### PR DESCRIPTION
Genre would rescroll to what ever was selected last after a new decade was selected.(this was fixed)
Sometimes when changing decade back to 'ALL' the app would display nothing. (this was fixed)